### PR TITLE
feat: default to auto mode for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Keep modules as pure function definitions and shared globals. Do not source indi
 - `lwt add <branch>` should stay non-interactive when the branch already exists locally or on `origin`; checking out an existing branch is the expected path, not a risky edge case.
 - `lwt remove` should preserve a clear automation path: `--yes` skips the delete prompt, `--force` handles dirty/unmerged local cleanup, and remote cleanup stays explicit behind `--delete-remote`.
 - The first-contact UX for `lwt` / `lwt --help` should teach automation-safe patterns early because agents discover the tool through help output, not just humans.
+- Default agent mode is `auto` (Claude's `--enable-auto-mode`). Codex and Gemini don't have auto mode, so `auto` behaves like `interactive` for them (plain launch, no flags). `-yolo` escalates to `--dangerously-skip-permissions` for Claude and `--yolo` for Codex/Gemini. `-i`/`--interactive` restores the old conservative behavior (ask for every permission).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Implementation note: `lwt.sh` remains the only entrypoint you source. It loads t
 ## Usage
 
 ```bash
-lwt add (a)        [branch] [-s] [-d] [-e] [-yolo]
+lwt add (a)        [branch] [-s] [-d] [-e] [-yolo] [-i]
                    [--claude ["prompt"]] [--codex ["prompt"]] [--gemini ["prompt"]]
                    [--agents list ["prompt"]] [--<agent-combo> ["prompt"]]
                    [--split "cmd"] [--tab "cmd"]
@@ -91,7 +91,7 @@ If an agent or script is driving `lwt`, prefer explicit targets over picker flow
 
 Avoid bare `lwt rm`, `lwt switch`, and `lwt checkout` in automation unless you are intentionally running them in a real TTY, because those flows rely on `fzf`.
 
-`-yolo` and `lwt config set agent-mode yolo` only affect Claude/Codex/Gemini permissions. They do not bypass `lwt` command confirmations.
+`-yolo`, `-i`, and `lwt config set agent-mode` only affect Claude/Codex/Gemini permissions. They do not bypass `lwt` command confirmations.
 
 ## Remote-Aware Status
 
@@ -166,10 +166,14 @@ The first agent flag determines which agent runs in your current shell; the rest
 lwt a feat-auth --codex "investigate edge cases" --claude "implement refresh token rotation"
 ```
 
-By default, agents launch in interactive mode. Pass `-yolo` to auto-approve all agent actions for that run, or set it globally:
+By default, agents launch in **auto mode**. For Claude, this uses `--enable-auto-mode`, which lets Claude make routine decisions autonomously while still asking for confirmation on higher-risk actions. For Codex and Gemini, auto mode is the same as interactive (plain launch, no flags) since they don't support auto mode yet.
+
+Pass `-yolo` to fully skip all permission checks (`--dangerously-skip-permissions` for Claude, `--yolo` for Codex/Gemini), or `-i`/`--interactive` for the old conservative behavior where agents ask for every permission:
 
 ```bash
-lwt config set agent-mode yolo
+lwt config set agent-mode yolo          # skip all permissions
+lwt config set agent-mode interactive   # ask for everything
+lwt config set agent-mode auto          # the default
 ```
 
 ## Terminal Automation
@@ -389,7 +393,7 @@ lwt config set editor zed
 ```bash
 lwt config show
 lwt config set editor zed
-lwt config set agent-mode yolo
+lwt config set agent-mode auto
 lwt config set dev-cmd "pnpm --filter web dev"
 lwt config set merge-target release
 lwt config add copy-on-create apps/typefully-web/.browser-auth.json

--- a/lib/agent.sh
+++ b/lib/agent.sh
@@ -45,7 +45,7 @@ lwt::agent::normalize_spec() {
 lwt::agent::command_string() {
   local agent="$1"
   local prompt="$2"
-  local yolo="$3"
+  local agent_mode="$3"
   local cmd=""
 
   [[ -z "$agent" ]] && return 1
@@ -57,15 +57,23 @@ lwt::agent::command_string() {
   case "$agent" in
     claude)
       cmd="claude"
-      [[ "$yolo" == "true" ]] && cmd="$cmd --dangerously-skip-permissions"
+      case "$agent_mode" in
+        yolo)
+          cmd="$cmd --dangerously-skip-permissions"
+          ;;
+        auto)
+          cmd="$cmd --enable-auto-mode"
+          ;;
+        # interactive: plain claude, no flags
+      esac
       ;;
     codex)
       cmd="codex"
-      [[ "$yolo" == "true" ]] && cmd="$cmd --yolo"
+      [[ "$agent_mode" == "yolo" ]] && cmd="$cmd --yolo"
       ;;
     gemini)
       cmd="gemini"
-      [[ "$yolo" == "true" ]] && cmd="$cmd --yolo"
+      [[ "$agent_mode" == "yolo" ]] && cmd="$cmd --yolo"
       ;;
     *)
       return 1
@@ -81,7 +89,7 @@ lwt::agent::command_string() {
 lwt::agent::launch() {
   local agent="$1"
   local prompt="$2"
-  local yolo="$3"
+  local agent_mode="$3"
   [[ -z "$agent" ]] && return 0
 
   if ! lwt::deps::has "$agent"; then
@@ -89,32 +97,42 @@ lwt::agent::launch() {
     return 0
   fi
 
-  # Resolve yolo mode: flag > config > default (interactive)
-  if [[ "$yolo" != "true" ]]; then
-    local configured
-    configured=$(lwt::config::get_effective "agent-mode" 2>/dev/null)
-    [[ "$configured" == "yolo" ]] && yolo=true
+  # Resolve agent mode: flag > config > default (auto)
+  if [[ -z "$agent_mode" ]]; then
+    agent_mode=$(lwt::config::get_effective "agent-mode" 2>/dev/null)
+    [[ -z "$agent_mode" ]] && agent_mode="auto"
   fi
 
   lwt::ui::step "Launching $agent..."
   case "$agent" in
     claude)
-      if [[ "$yolo" == "true" ]]; then
-        if [[ -n "$prompt" ]]; then
-          claude --dangerously-skip-permissions "$prompt"
-        else
-          claude --dangerously-skip-permissions
-        fi
-      else
-        if [[ -n "$prompt" ]]; then
-          claude "$prompt"
-        else
-          claude
-        fi
-      fi
+      case "$agent_mode" in
+        yolo)
+          if [[ -n "$prompt" ]]; then
+            claude --dangerously-skip-permissions "$prompt"
+          else
+            claude --dangerously-skip-permissions
+          fi
+          ;;
+        auto)
+          if [[ -n "$prompt" ]]; then
+            claude --enable-auto-mode "$prompt"
+          else
+            claude --enable-auto-mode
+          fi
+          ;;
+        *)
+          # interactive: plain claude
+          if [[ -n "$prompt" ]]; then
+            claude "$prompt"
+          else
+            claude
+          fi
+          ;;
+      esac
       ;;
     codex)
-      if [[ "$yolo" == "true" ]]; then
+      if [[ "$agent_mode" == "yolo" ]]; then
         if [[ -n "$prompt" ]]; then
           codex --yolo "$prompt"
         else
@@ -129,7 +147,7 @@ lwt::agent::launch() {
       fi
       ;;
     gemini)
-      if [[ "$yolo" == "true" ]]; then
+      if [[ "$agent_mode" == "yolo" ]]; then
         if [[ -n "$prompt" ]]; then
           gemini --yolo "$prompt"
         else

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -387,6 +387,7 @@ lwt::cmd::add() {
   local run_setup=false
   local run_dev=false
   local yolo=false
+  local interactive=false
   local editor_override=""
   local main_agent=""
   local main_agent_prompt=""
@@ -414,6 +415,10 @@ lwt::cmd::add() {
         ;;
       -yolo)
         yolo=true
+        ;;
+      -i|--interactive)
+        yolo=false
+        interactive=true
         ;;
       -e|--editor)
         open_editor=true
@@ -662,11 +667,15 @@ lwt::cmd::add() {
     lwt::editor::open "$target" "$editor_override"
   fi
 
-  local resolved_yolo="$yolo"
-  if [[ "$resolved_yolo" != "true" ]]; then
-    local configured_agent_mode
-    configured_agent_mode=$(lwt::config::get_effective "agent-mode" 2>/dev/null)
-    [[ "$configured_agent_mode" == "yolo" ]] && resolved_yolo=true
+  # Resolve agent mode: flag > config > default (auto)
+  local resolved_agent_mode=""
+  if [[ "$yolo" == "true" ]]; then
+    resolved_agent_mode="yolo"
+  elif [[ "$interactive" == "true" ]]; then
+    resolved_agent_mode="interactive"
+  else
+    resolved_agent_mode=$(lwt::config::get_effective "agent-mode" 2>/dev/null)
+    [[ -z "$resolved_agent_mode" ]] && resolved_agent_mode="auto"
   fi
 
   for agent_name in "${missing_agents[@]}"; do
@@ -708,7 +717,7 @@ lwt::cmd::add() {
 
     local _fi
     for (( _fi = 1; _fi <= ${#parallel_agents[@]}; _fi++ )); do
-      fallback_command=$(lwt::agent::command_string "${parallel_agents[$_fi]}" "${parallel_prompts[$_fi]}" "$resolved_yolo") || continue
+      fallback_command=$(lwt::agent::command_string "${parallel_agents[$_fi]}" "${parallel_prompts[$_fi]}" "$resolved_agent_mode") || continue
       lwt::ui::hint "Manual launch: cd $(lwt::shell::quote "$target") && $fallback_command"
     done
     parallel_agents=()
@@ -743,7 +752,7 @@ lwt::cmd::add() {
   # Launch parallel agent splits
   local _pi
   for (( _pi = 1; _pi <= ${#parallel_agents[@]}; _pi++ )); do
-    session_command=$(lwt::agent::command_string "${parallel_agents[$_pi]}" "${parallel_prompts[$_pi]}" "$resolved_yolo") || continue
+    session_command=$(lwt::agent::command_string "${parallel_agents[$_pi]}" "${parallel_prompts[$_pi]}" "$resolved_agent_mode") || continue
 
     lwt::ui::step "Opening split for ${parallel_agents[$_pi]}..."
     if ! lwt::terminal::launch "$terminal_driver" "split" "$target" "$session_command"; then
@@ -752,7 +761,7 @@ lwt::cmd::add() {
   done
 
   # Launch main agent in current shell
-  lwt::agent::launch "$main_agent" "$main_agent_prompt" "$yolo"
+  lwt::agent::launch "$main_agent" "$main_agent_prompt" "$resolved_agent_mode"
 
   # --dev without agents: run dev command in the current shell
   if $run_dev && (( ${#agent_names[@]} == 0 )); then
@@ -2039,7 +2048,7 @@ lwt::cmd::doctor() {
 
   local agent_mode
   agent_mode=$(lwt::config::get_effective "agent-mode" 2>/dev/null)
-  echo "  ${_lwt_green}✓ agent-mode${_lwt_reset} ${agent_mode:-interactive}"
+  echo "  ${_lwt_green}✓ agent-mode${_lwt_reset} ${agent_mode:-auto}"
 
   local dev_cmd
   dev_cmd=$(lwt::config::get_raw "dev-cmd" 2>/dev/null)

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -121,7 +121,7 @@ lwt::config::default_value() {
       printf '%s\n' "${LWT_EDITOR:-${VISUAL:-${EDITOR:-}}}"
       ;;
     agent-mode)
-      printf 'interactive\n'
+      printf 'auto\n'
       ;;
     dev-cmd)
       printf 'auto\n'
@@ -215,7 +215,7 @@ lwt::config::description() {
       printf 'Editor command used by --editor and editor-aware flows\n'
       ;;
     agent-mode)
-      printf 'Default agent approval mode for Claude, Codex, and Gemini\n'
+      printf 'Default agent permission mode: auto, yolo, or interactive\n'
       ;;
     dev-cmd)
       printf 'Project dev command used by lwt add --dev\n'

--- a/lib/help.sh
+++ b/lib/help.sh
@@ -27,7 +27,8 @@ lwt::ui::help_main() {
   echo "  lwt a existing-branch                      ${_lwt_dim}Check out an existing branch without prompting${_lwt_reset}"
   echo "  lwt a my-feature --claude \"fix...\"         ${_lwt_dim}Create and launch an agent${_lwt_reset}"
   echo "  lwt a my-feature --claude \"fix\" --codex \"review\" ${_lwt_dim}First agent here, second in split${_lwt_reset}"
-  echo "  lwt a my-feature -yolo --claude \"fix...\"   ${_lwt_dim}Launch agent with full auto-approve${_lwt_reset}"
+  echo "  lwt a my-feature -yolo --claude \"fix...\"   ${_lwt_dim}Launch agent with full auto-approve (skip all permissions)${_lwt_reset}"
+  echo "  lwt a my-feature -i --claude \"fix...\"     ${_lwt_dim}Launch agent in interactive mode (ask for every permission)${_lwt_reset}"
   echo "  lwt rm my-feature --yes                    ${_lwt_dim}Remove a worktree without an interactive prompt${_lwt_reset}"
   echo "  lwt rm my-feature --yes --force            ${_lwt_dim}Also discard local changes if needed${_lwt_reset}"
   echo "  lwt a my-feature -e                        ${_lwt_dim}Create and open in editor${_lwt_reset}"
@@ -43,7 +44,7 @@ lwt::ui::help_main() {
   echo
   lwt::ui::header "Config"
   echo "  lwt config set editor zed                   ${_lwt_dim}Editor to open worktrees in${_lwt_reset}"
-  echo "  lwt config set agent-mode yolo              ${_lwt_dim}Auto-approve all agent actions${_lwt_reset}"
+  echo "  lwt config set agent-mode auto              ${_lwt_dim}Claude auto mode (default), yolo for full skip, interactive for manual${_lwt_reset}"
   echo "  lwt config set dev-cmd \"pnpm dev\"          ${_lwt_dim}Default command for --dev${_lwt_reset}"
   echo "  lwt config set terminal ghostty             ${_lwt_dim}Preferred terminal driver for splits/tabs${_lwt_reset}"
   echo "  lwt config add copy-on-create path/to/file  ${_lwt_dim}Repeatable repo-local copies for add/checkout${_lwt_reset}"
@@ -64,7 +65,7 @@ lwt::ui::help_automation() {
   echo "  lwt rm feat-auth --yes --delete-remote     ${_lwt_dim}Also delete the remote branch or close the open PR${_lwt_reset}"
   echo
   lwt::ui::header "Agent Notes"
-  echo "  ${_lwt_dim}-yolo and agent-mode yolo control Claude/Codex/Gemini permissions, not lwt confirmations.${_lwt_reset}"
+  echo "  ${_lwt_dim}-yolo, -i, and agent-mode control Claude/Codex/Gemini permissions, not lwt confirmations.${_lwt_reset}"
   echo "  ${_lwt_dim}If you need picker-based flows, run lwt in a real TTY.${_lwt_reset}"
 }
 
@@ -82,7 +83,8 @@ lwt::ui::help_add() {
   echo "  ${_lwt_bold}--split \"cmd\"${_lwt_reset}            ${_lwt_dim}Run a command in a new terminal split${_lwt_reset}"
   echo "  ${_lwt_bold}--tab \"cmd\"${_lwt_reset}              ${_lwt_dim}Run a command in a new terminal tab${_lwt_reset}"
   echo "  ${_lwt_bold}-d, --dev${_lwt_reset}                 ${_lwt_dim}Run the repo's dev command (in place, or split if an agent is running)${_lwt_reset}"
-  echo "  ${_lwt_bold}-yolo${_lwt_reset}                    ${_lwt_dim}Give agents full auto-approve permissions${_lwt_reset}"
+  echo "  ${_lwt_bold}-yolo${_lwt_reset}                    ${_lwt_dim}Give agents full auto-approve permissions (--dangerously-skip-permissions)${_lwt_reset}"
+  echo "  ${_lwt_bold}-i, --interactive${_lwt_reset}        ${_lwt_dim}Launch agents in interactive mode (ask for every permission)${_lwt_reset}"
   echo "  ${_lwt_bold}-h, --help${_lwt_reset}               ${_lwt_dim}Show help${_lwt_reset}"
   echo
   lwt::ui::header "Notes"
@@ -97,7 +99,8 @@ lwt::ui::help_add() {
   echo "  ${_lwt_dim}Use lwt config add copy-on-create <repo-path> for extra files or directories copied into new worktrees.${_lwt_reset}"
   echo "  ${_lwt_dim}Configured directories copy recursively into the same relative path. Use hooks only for scripted logic.${_lwt_reset}"
   echo "  ${_lwt_dim}Split/tab automation currently supports Ghostty and iTerm2 on macOS.${_lwt_reset}"
-  echo "  ${_lwt_dim}Set yolo globally with: lwt config set agent-mode yolo${_lwt_reset}"
+  echo "  ${_lwt_dim}Default agent mode is auto (Claude's --enable-auto-mode). Override with -yolo or -i.${_lwt_reset}"
+  echo "  ${_lwt_dim}Set globally with: lwt config set agent-mode yolo|auto|interactive${_lwt_reset}"
 }
 
 lwt::ui::help_switch() {
@@ -222,7 +225,7 @@ lwt::ui::help_config() {
   echo
   lwt::ui::header "Keys"
   echo "  ${_lwt_bold}editor${_lwt_reset}                        ${_lwt_dim}Global by default${_lwt_reset}"
-  echo "  ${_lwt_bold}agent-mode${_lwt_reset}                    ${_lwt_dim}Global by default; interactive or yolo${_lwt_reset}"
+  echo "  ${_lwt_bold}agent-mode${_lwt_reset}                    ${_lwt_dim}Global by default; auto (default), yolo, or interactive${_lwt_reset}"
   echo "  ${_lwt_bold}dev-cmd${_lwt_reset}                       ${_lwt_dim}Local by default${_lwt_reset}"
   echo "  ${_lwt_bold}terminal${_lwt_reset}                      ${_lwt_dim}Global by default; auto, ghostty, iterm2${_lwt_reset}"
   echo "  ${_lwt_bold}merge-target${_lwt_reset}                  ${_lwt_dim}Local by default${_lwt_reset}"


### PR DESCRIPTION
## What

Changes the default agent permission mode from **interactive** to **auto**.

Auto mode uses Claude Code's new `--enable-auto-mode` flag ([announcement](https://claude.com/blog/auto-mode)), which lets Claude make routine permission decisions autonomously while a classifier blocks potentially destructive actions. This is a safer middle ground between interactive (ask for everything) and `--dangerously-skip-permissions`.

## Permission modes

| Mode | Claude | Codex / Gemini | Flag |
|---|---|---|---|
| **auto** (new default) | `--enable-auto-mode` | plain (no flags) | _(none)_ |
| **yolo** | `--dangerously-skip-permissions` | `--yolo` | `-yolo` |
| **interactive** | plain (ask everything) | plain (ask everything) | `-i` / `--interactive` |

## Changes

- `lib/agent.sh` — `command_string` and `launch` now accept `auto`/`yolo`/`interactive` instead of a boolean
- `lib/commands.sh` — adds `-i`/`--interactive` flag, resolves mode from flag > config > default (auto)
- `lib/config.sh` — default `agent-mode` changed from `interactive` to `auto`
- `lib/help.sh` — updated help text for all affected commands
- `README.md` — updated docs

## Note

Auto mode is currently available as a research preview on Claude Team plan, rolling out to Enterprise and API soon. For Codex and Gemini, auto mode behaves the same as interactive since they don't have an equivalent feature yet.