### PR TITLE
feat: honor .worktreeinclude in worktree creation

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Local agent/app settings that should follow fresh managed worktrees.
+.claude/settings.local.json
+.codex/environments/environment.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Keep modules as pure function definitions and shared globals. Do not source indi
 - `lwt restack` should stay scoped to the current linked worktree. Automatic target selection applies to branches created with `lwt add --from <branch>` and to branches `lwt add` created from the repo default branch. Older worktrees without remembered metadata may fall back to the repo default branch in the restack summary, but automation should still stay explicit with `--onto`.
 - Agent-facing flows should print absolute worktree paths explicitly; do not rely on in-process `cd` state or path-free summaries.
 - `lwt remove` should preserve a clear automation path: `--yes` skips the delete prompt, `--force` handles dirty/unmerged local cleanup, and remote cleanup stays explicit behind `--delete-remote`.
+- `lwt add` and `lwt checkout` should honor root `.worktreeinclude` before `copy-on-create`: copy only files matched by `.worktreeinclude` and ignored by Git, skip symlinks and existing targets, and use the legacy actual `.env*` copy fallback only when `.worktreeinclude` is absent.
 - The first-contact UX for `lwt` / `lwt --help` should teach automation-safe patterns early because agents discover the tool through help output, not just humans.
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -309,9 +309,21 @@ lwt config set terminal ghostty
 
 Use `lwt doctor` to confirm whether terminal automation is available and which driver was detected.
 
-## Copy Extra Files On Create
+## Copy Local Files On Create
 
-For simple project-specific bootstrapping, use `copy-on-create` instead of a hook.
+For shared ignored local files, add a root `.worktreeinclude`. It uses `.gitignore` syntax and is applied by both `lwt add` and `lwt checkout` after the Git worktree exists and before editors, terminals, agents, or hooks run.
+
+Only files that are also ignored by Git are copied. Existing files in the target worktree are left alone, and symlinks are skipped. If `.worktreeinclude` is present, it replaces the older automatic `.env*` copy behavior, so include env patterns explicitly when you want them:
+
+```gitignore
+.env
+.env.*
+apps/typefully-web/.browser-auth.json
+```
+
+When no `.worktreeinclude` exists, `lwt` keeps its legacy fallback and copies actual `.env` files such as `.env`, `.env.local`, and `.env.production.local`. Template/example files like `.env.example` are skipped.
+
+For extra local copies that should not be part of the shared `.worktreeinclude` contract, use `copy-on-create` instead of a hook.
 
 Each configured path is repo-relative:
 
@@ -325,7 +337,7 @@ This is the simplest way to seed extra local-only files like browser auth state:
 lwt config add copy-on-create apps/typefully-web/.browser-auth.json
 ```
 
-That applies to both `lwt add` and `lwt checkout`, after actual `.env` files (for example `.env`, `.env.local`, `.env.production.local`) are copied and before editors, terminals, or agents launch. Template/example files like `.env.example` are skipped.
+That applies to both `lwt add` and `lwt checkout`, after `.worktreeinclude` files or the legacy `.env*` fallback are copied.
 
 Use hooks only when you need conditional or scripted behavior.
 
@@ -493,7 +505,7 @@ Supported keys:
 - `dev-cmd`
 - `terminal`
 - `merge-target`
-- `copy-on-create` (repeatable, repo-relative path copied by `add` and `checkout`)
+- `copy-on-create` (repeatable, repo-relative path copied by `add` and `checkout` after `.worktreeinclude`)
 
 `lwt config show` intentionally hides advanced/internal settings. The default view is meant to stay small.
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -227,7 +227,7 @@ lwt::config::description() {
       printf 'Default target branch for merge flows\n'
       ;;
     copy-on-create)
-      printf 'Repeatable repo-relative path copied into new worktrees; directories copy recursively\n'
+      printf 'Repeatable repo-relative path copied after .worktreeinclude; directories copy recursively\n'
       ;;
     hook.*)
       printf 'Shell command run for %s\n' "${key#hook.}"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -149,6 +149,79 @@ lwt::utils::copy_env_files() {
   fi
 }
 
+lwt::utils::copy_worktreeinclude_files() {
+  local repo_root="$1"
+  local target="$2"
+  local include_file="$repo_root/.worktreeinclude"
+  local rel src dest dest_dir
+  local copied_count=0
+  local skipped_existing_count=0
+  local skipped_symlink_count=0
+  local skipped_unignored_count=0
+
+  [[ -f "$include_file" ]] || return 0
+
+  while IFS= read -r -d '' rel; do
+    [[ -n "$rel" ]] || continue
+
+    case "$rel" in
+      /*|../*|*/../*)
+        continue
+        ;;
+    esac
+
+    src="$repo_root/$rel"
+    dest="$target/$rel"
+
+    [[ -e "$src" || -L "$src" ]] || continue
+
+    # Managed-worktree tools only copy paths that are both included and
+    # gitignored. Keeping the same rule here makes .worktreeinclude portable.
+    if ! git -C "$repo_root" check-ignore -q -- "$rel"; then
+      ((skipped_unignored_count++))
+      continue
+    fi
+
+    if [[ -L "$src" ]]; then
+      ((skipped_symlink_count++))
+      continue
+    fi
+
+    [[ -f "$src" ]] || continue
+
+    if [[ -e "$dest" || -L "$dest" ]]; then
+      ((skipped_existing_count++))
+      continue
+    fi
+
+    dest_dir="$(dirname "$dest")"
+    mkdir -p "$dest_dir" || return 1
+    cp -p "$src" "$dest" || return 1
+    ((copied_count++))
+  done < <(git -C "$repo_root" ls-files -o -i --exclude-from="$include_file" -z 2>/dev/null)
+
+  if ((copied_count > 0)); then
+    local s="s"; ((copied_count == 1)) && s=""
+    lwt::ui::step "Copied $copied_count file$s from .worktreeinclude"
+  fi
+
+  if ((skipped_existing_count > 0)); then
+    local s="s"; ((skipped_existing_count == 1)) && s=""
+    lwt::ui::step "Skipped $skipped_existing_count existing file$s from .worktreeinclude"
+  fi
+
+  if ((skipped_symlink_count > 0)); then
+    local s="s"; ((skipped_symlink_count == 1)) && s=""
+    lwt::ui::warn "Skipped $skipped_symlink_count symlink$s from .worktreeinclude."
+  fi
+
+  if ((skipped_unignored_count > 0)); then
+    local s="s"; ((skipped_unignored_count == 1)) && s=""
+    lwt::ui::warn "Skipped $skipped_unignored_count file$s from .worktreeinclude that Git does not ignore."
+    lwt::ui::hint ".worktreeinclude copies only ignored local files; add the path to .gitignore or use copy-on-create."
+  fi
+}
+
 lwt::utils::is_actual_env_file() {
   local path="$1"
   local base="${path:t}"

--- a/lib/help.sh
+++ b/lib/help.sh
@@ -47,14 +47,14 @@ lwt::ui::help_main() {
   echo "  lwt rs --yes                               ${_lwt_dim}Restack the current child worktree non-interactively${_lwt_reset}"
   echo "  lwt config show                            ${_lwt_dim}See effective settings and where they come from${_lwt_reset}"
   echo "  lwt config set dev-cmd \"pnpm dev\"         ${_lwt_dim}Persist the repo dev command${_lwt_reset}"
-  echo "  lwt config add copy-on-create apps/typefully-web/.browser-auth.json ${_lwt_dim}Copy extra project files into new worktrees${_lwt_reset}"
+  echo "  lwt config add copy-on-create apps/typefully-web/.browser-auth.json ${_lwt_dim}Copy an extra project file into new worktrees${_lwt_reset}"
   echo
   lwt::ui::header "Config"
   echo "  lwt config set editor zed                   ${_lwt_dim}Editor to open worktrees in${_lwt_reset}"
   echo "  lwt config set agent-mode yolo              ${_lwt_dim}Auto-approve all agent actions${_lwt_reset}"
   echo "  lwt config set dev-cmd \"pnpm dev\"          ${_lwt_dim}Default command for --dev${_lwt_reset}"
   echo "  lwt config set terminal ghostty             ${_lwt_dim}Preferred terminal driver for splits/tabs${_lwt_reset}"
-  echo "  lwt config add copy-on-create path/to/file  ${_lwt_dim}Repeatable repo-local copies for add/checkout${_lwt_reset}"
+  echo "  lwt config add copy-on-create path/to/file  ${_lwt_dim}Extra repo-local copies for add/checkout${_lwt_reset}"
 }
 
 lwt::ui::help_automation() {
@@ -119,13 +119,16 @@ lwt::ui::help_add() {
   echo "  ${_lwt_dim}--from-current uses the current commit only; uncommitted changes stay in the current worktree.${_lwt_reset}"
   echo "  ${_lwt_dim}If the branch already exists locally or on origin, lwt checks it out into a worktree instead of creating a new branch.${_lwt_reset}"
   echo "  ${_lwt_dim}If the target branch already exists, explicit start-point flags are rejected instead of being ignored.${_lwt_reset}"
+  echo "  ${_lwt_dim}If .worktreeinclude exists, lwt copies matching gitignored files without overwriting existing targets.${_lwt_reset}"
+  echo "  ${_lwt_dim}Without .worktreeinclude, lwt keeps its legacy fallback of copying actual .env files.${_lwt_reset}"
   echo "  ${_lwt_dim}After creation, lwt prints the absolute path and a ready-to-run cd command.${_lwt_reset}"
   echo "  ${_lwt_dim}First agent runs in your shell; additional agents open in splits automatically.${_lwt_reset}"
   echo "  ${_lwt_dim}Each agent flag takes its own prompt: --claude \"fix auth\" --codex \"review tests\"${_lwt_reset}"
   echo "  ${_lwt_dim}Hyphen aliases like --claude-codex share one prompt across all agents in the alias.${_lwt_reset}"
   echo "  ${_lwt_dim}When an agent flag is used, dependencies are always installed.${_lwt_reset}"
   echo "  ${_lwt_dim}Set dev-cmd for monorepos or non-standard dev commands with lwt config set dev-cmd ...${_lwt_reset}"
-  echo "  ${_lwt_dim}Use lwt config add copy-on-create <repo-path> for extra files or directories copied into new worktrees.${_lwt_reset}"
+  echo "  ${_lwt_dim}Use .worktreeinclude for shared ignored local files copied into new worktrees.${_lwt_reset}"
+  echo "  ${_lwt_dim}Use lwt config add copy-on-create <repo-path> for extra per-repo copies outside that contract.${_lwt_reset}"
   echo "  ${_lwt_dim}Configured directories copy recursively into the same relative path. Use hooks only for scripted logic.${_lwt_reset}"
   echo "  ${_lwt_dim}Split/tab automation currently supports Ghostty and iTerm2 on macOS.${_lwt_reset}"
   echo "  ${_lwt_dim}Set yolo globally with: lwt config set agent-mode yolo${_lwt_reset}"
@@ -312,8 +315,9 @@ lwt::ui::help_config() {
   echo "  ${_lwt_bold}dev-cmd${_lwt_reset}                       ${_lwt_dim}Local by default${_lwt_reset}"
   echo "  ${_lwt_bold}terminal${_lwt_reset}                      ${_lwt_dim}Global by default; auto, ghostty, iterm2${_lwt_reset}"
   echo "  ${_lwt_bold}merge-target${_lwt_reset}                  ${_lwt_dim}Local by default${_lwt_reset}"
-  echo "  ${_lwt_bold}copy-on-create${_lwt_reset}                ${_lwt_dim}Local by default; repeatable repo-relative file/dir copied by add/checkout${_lwt_reset}"
+  echo "  ${_lwt_bold}copy-on-create${_lwt_reset}                ${_lwt_dim}Local by default; repeatable repo-relative file/dir copied after .worktreeinclude${_lwt_reset}"
   echo
+  echo "  ${_lwt_dim}.worktreeinclude is the shared ignored-file contract for add/checkout when present.${_lwt_reset}"
   echo "  ${_lwt_dim}Directories configured in copy-on-create are copied recursively into the same relative path.${_lwt_reset}"
   echo "  ${_lwt_dim}Advanced hook settings exist, but they are intentionally hidden from the default output.${_lwt_reset}"
 }

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -270,7 +270,15 @@ lwt::worktree::create_branch() {
     lwt::ui::step "Created branch ${_lwt_bold}$branch${_lwt_reset}${_lwt_dim} from ${start_ref_label}"
   fi
 
-  lwt::utils::copy_env_files "$repo_root" "$target"
+  if [[ -f "$repo_root/.worktreeinclude" ]]; then
+    lwt::utils::copy_worktreeinclude_files "$repo_root" "$target" || {
+      lwt::ui::error "Failed to copy .worktreeinclude files."
+      return 1
+    }
+  else
+    lwt::utils::copy_env_files "$repo_root" "$target"
+  fi
+
   lwt::utils::copy_configured_paths "$repo_root" "$target" || {
     lwt::ui::error "Failed to copy configured create-time paths."
     return 1


### PR DESCRIPTION
## TL;DR

`lwt add` and `lwt checkout` now understand the same `.worktreeinclude` contract used by managed worktree tools. Repos can declare ignored local files once, while `lwt` keeps the old `.env*` fallback for projects that have not opted in yet.

## Summary

- Introduce **`.worktreeinclude` copying** during worktree creation, limited to files that are both matched by `.worktreeinclude` and ignored by Git, with existing targets and source symlinks skipped for safer local state handling.
- Preserve **legacy `.env*` fallback behavior** when a repo has no `.worktreeinclude`, while making `.worktreeinclude` take precedence when present so env patterns must be declared explicitly.
- Add **repo-owned `.worktreeinclude` docs and config guidance** for local Claude/Codex settings, README copy behavior, CLI help, and future agent notes.

## Validation

- [x] `zsh -n lwt.sh lib/*.sh`
- [x] `source lwt.sh && lwt help add`
- [x] `source lwt.sh && lwt help config`
- [x] `source lwt.sh && lwt config show`
- [x] Temp repo `lwt add` smoke test with `.worktreeinclude`, ignored files, unignored candidate, and symlink
- [x] Temp repo `lwt add` smoke test without `.worktreeinclude` for legacy `.env*` fallback
- [x] `git check-ignore -v .claude/settings.local.json .codex/environments/environment.toml`
- [x] `git diff --check`

## Manual QA

- [ ] In a real repo with `.worktreeinclude`, run `lwt add <branch>` and confirm only listed gitignored local files copy into the new worktree.
- [ ] In a repo without `.worktreeinclude`, run `lwt add <branch>` and confirm actual `.env` files still copy while templates stay out.

## After Merge

*No action required*